### PR TITLE
Update readme to reflect to latest site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 ![logo](https://raw.githubusercontent.com/HMXMilohax/RB3DX-Site/main/docs/images/logo.gif)
-# RB3DX Website Repository
-
-# [Neocities](https://rb3dx.neocities.org/) [![Deploy to neocities](https://github.com/hmxmilohax/RB3DX-Site/actions/workflows/deploy.yml/badge.svg)](https://github.com/hmxmilohax/RB3DX-Site/actions/workflows/deploy.yml) ![View Count](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fneocities.org%2Fapi%2Finfo%3Fsitename%3Drb3dx&query=%24.info.views&label=Site%20Views)
-# [GitHub Pages Mirror](https://hmxmilohax.github.io/RB3DX-Site/) [![pages-build-deployment](https://github.com/hmxmilohax/RB3DX-Site/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/hmxmilohax/RB3DX-Site/actions/workflows/pages/pages-build-deployment)
+# RB3DX Website
+# [Visit Website](https://rb3dx.milohax.org/) [![pages-build-deployment](https://github.com/hmxmilohax/RB3DX-Site/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/hmxmilohax/RB3DX-Site/actions/workflows/pages/pages-build-deployment)


### PR DESCRIPTION
Removes neocities link and renames the GitHub Pages mirror and changes it to current URL